### PR TITLE
Linking the user profile to fedora account info

### DIFF
--- a/src/auth/platformUrl.ts
+++ b/src/auth/platformUrl.ts
@@ -20,6 +20,6 @@ export default function platformUlr(env: typeof DEFAULT_SSO_ROUTES, configSsoUrl
     return sanitizeUrl(ssoEnv?.[1].sso);
   } else {
     log('SSO url: not found, defaulting to stage');
-    return DEFAULT_SSO_ROUTES.stage.sso;
+    return DEFAULT_SSO_ROUTES.stg.sso;
   }
 }

--- a/src/components/Header/UserToggle.tsx
+++ b/src/components/Header/UserToggle.tsx
@@ -81,7 +81,7 @@ const DropdownItems = ({
       {!isITLessEnv && (
         <DropdownItem
           key="My Profile"
-          to={`https://www.${prefix}redhat.com/wapps/ugc/protected/personalInfo.html`}
+          to={`https://accounts.${prefix}fedoraproject.org/user/${username}`}
           target="_blank"
           rel="noopener noreferrer"
           component="a"

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -12,7 +12,7 @@ export const DEFAULT_SSO_ROUTES = {
     sso: '',
     portal: '',
   },
-  stage: {
+  stg: {
     url: ['console.stg.foo.fedorainfracloud.org', 'console.stg.fedorainfracloud.org'],
     sso: 'https://id.stg.fedoraproject.org/openidc/',
     portal: 'https://accounts.stg.fedoraproject.org',


### PR DESCRIPTION
The user profile is now redirecting to the console account profile we want to map it to the Fedora account of the logged-in user.