### PR TITLE
Linking the user profile to fedora account info and removing mobile view params

### DIFF
--- a/src/components/Header/Tools.tsx
+++ b/src/components/Header/Tools.tsx
@@ -32,10 +32,6 @@ const Tools = () => {
   const { user, token } = useContext(ChromeAuthContext);
   const intl = useIntl();
 
-  const betaSwitcherTitle = `${isPreview ? intl.formatMessage(messages.stopUsing) : intl.formatMessage(messages.use)} ${intl.formatMessage(
-    messages.betaRelease
-  )}`;
-
   useEffect(() => {
     if (user) {
       setState({
@@ -73,17 +69,6 @@ const Tools = () => {
       title: intl.formatMessage(messages.supportOptions),
       onClick: () => (window.location.href = supportOptionsUrl()),
     },
-  ];
-
-  /* Combine aboutMenuItems with a settings link on mobile */
-  const mobileDropdownItems = [
-    { title: 'separator' },
-    {
-      title: betaSwitcherTitle,
-      onClick: () => togglePreviewWithCheck(),
-    },
-    { title: 'separator' },
-    ...aboutMenuDropdownItems,
   ];
 
   /* QuestionMark icon that should be used for "help/support" things */
@@ -138,22 +123,6 @@ const Tools = () => {
         <Tooltip aria="none" aria-live="polite" content={'More options'} flipBehavior={['bottom']}>
           <UserToggle
             isSmall
-            extraItems={mobileDropdownItems.map((action, key) => (
-              <React.Fragment key={key}>
-                {action.title === 'separator' ? (
-                  <Divider component="li" />
-                ) : (
-                  <DropdownItem
-                    {...(action.onClick && {
-                      component: 'button',
-                      onClick: action.onClick,
-                    })}
-                  >
-                    {action.title}
-                  </DropdownItem>
-                )}
-              </React.Fragment>
-            ))}
           />
         </Tooltip>
       </ToolbarItem>

--- a/src/components/Header/UserToggle.tsx
+++ b/src/components/Header/UserToggle.tsx
@@ -3,6 +3,7 @@ import './UserToggle.scss';
 import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core/dist/dynamic/components/Dropdown';
 import { ITLess, getEnv, isProd as isProdEnv } from '../../utils/common';
 import React, { useContext, useRef, useState } from 'react';
+import { DEFAULT_SSO_ROUTES } from '../../utils/common';
 
 import { Divider } from '@patternfly/react-core/dist/dynamic/components/Divider';
 import { EllipsisVIcon } from '@patternfly/react-icons/dist/dynamic/icons/ellipsis-v-icon';
@@ -81,7 +82,7 @@ const DropdownItems = ({
       {!isITLessEnv && (
         <DropdownItem
           key="My Profile"
-          to={`https://www.${prefix}redhat.com/wapps/ugc/protected/personalInfo.html`}
+          to={`${DEFAULT_SSO_ROUTES[env].portal}/user/${username}`}
           target="_blank"
           rel="noopener noreferrer"
           component="a"


### PR DESCRIPTION


https://github.com/user-attachments/assets/94781fbc-2d22-4b41-95ce-074609694774

1 . The user profile is now redirecting to the console account profile we want to map it to the Fedora account of the logged-in user.
2 . Removes some params that are visible in mobile view (ref - https://github.com/FedoraConsole/community-chrome/pull/3#pullrequestreview-2627481925)